### PR TITLE
add callback for end of a session

### DIFF
--- a/include/libKitsunemimiProjectCommon/network_session/session.h
+++ b/include/libKitsunemimiProjectCommon/network_session/session.h
@@ -106,7 +106,7 @@ private:
 
     // callbacks
     void* m_sessionTarget = nullptr;
-    void (*m_processSession)(void*, Session*, const uint64_t);
+    void (*m_processSession)(void*, bool, Session*, const uint64_t);
     void* m_dataTarget = nullptr;
     void (*m_processData)(void*, Session*, const bool, const void*, const uint64_t);
     void* m_errorTarget = nullptr;

--- a/include/libKitsunemimiProjectCommon/network_session/session_controller.h
+++ b/include/libKitsunemimiProjectCommon/network_session/session_controller.h
@@ -44,7 +44,7 @@ class SessionController
 {
 public:
     SessionController(void* sessionTarget,
-                      void (*processSession)(void*, Session*, const uint64_t),
+                      void (*processSession)(void*, bool, Session*, const uint64_t),
                       void* dataTarget,
                       void (*processData)(void*, Session*, const bool, const void*, const uint64_t),
                       void* errorTarget,

--- a/src/network_session/internal_session_interface.cpp
+++ b/src/network_session/internal_session_interface.cpp
@@ -53,6 +53,7 @@ namespace Common
  */
 InternalSessionInterface::InternalSessionInterface(void* sessionTarget,
                                                    void (*processSession)(void*,
+                                                                          bool,
                                                                           Session*,
                                                                           const uint64_t),
                                                    void* dataTarget,

--- a/src/network_session/internal_session_interface.h
+++ b/src/network_session/internal_session_interface.h
@@ -50,6 +50,7 @@ class InternalSessionInterface
 public:
     InternalSessionInterface(void* sessionTarget,
                              void (*processSession)(void*,
+                                                    bool,
                                                     Session*,
                                                     const uint64_t),
                              void* dataTarget,
@@ -110,7 +111,7 @@ public:
 private:
     // callbacks
     void* m_sessionTarget = nullptr;
-    void (*m_processSession)(void*, Session*, const uint64_t);
+    void (*m_processSession)(void*, bool, Session*, const uint64_t);
     void* m_dataTarget = nullptr;
     void (*m_processData)(void*, Session*, const bool, const void*, const uint64_t);
     void* m_errorTarget = nullptr;

--- a/src/network_session/session.cpp
+++ b/src/network_session/session.cpp
@@ -241,7 +241,7 @@ Session::makeSessionReady(const uint32_t sessionId,
         m_sessionId = sessionId;
         m_sessionIdentifier = sessionIdentifier;
 
-        m_processSession(m_sessionTarget, this, m_sessionIdentifier);
+        m_processSession(m_sessionTarget, true, this, m_sessionIdentifier);
 
         return true;
     }
@@ -350,6 +350,8 @@ Session::endSession(const bool init)
     // try to stop the session
     if(m_statemachine.goToNextState(STOP_SESSION))
     {
+        m_processSession(m_sessionTarget, false, this, m_sessionIdentifier);
+
         m_sessionReady = false;
         if(init) {
             send_Session_Close_Start(this, false);

--- a/src/network_session/session_constroller.cpp
+++ b/src/network_session/session_constroller.cpp
@@ -51,6 +51,7 @@ SessionController* SessionController::m_sessionController = nullptr;
  */
 SessionController::SessionController(void* sessionTarget,
                                      void (*processSession)(void*,
+                                                            bool,
                                                             Session*,
                                                             const uint64_t),
                                      void* dataTarget,

--- a/src/network_session/session_handler.cpp
+++ b/src/network_session/session_handler.cpp
@@ -48,7 +48,7 @@ InternalSessionInterface* SessionHandler::m_sessionInterface = nullptr;
  * @brief constructor
  */
 SessionHandler::SessionHandler(void* sessionTarget,
-                               void (*processSession)(void*, Session*, const uint64_t),
+                               void (*processSession)(void*, bool, Session*, const uint64_t),
                                void* dataTarget,
                                void (*processData)(void*, Session*, const bool,
                                                    const void*, const uint64_t),

--- a/src/network_session/session_handler.h
+++ b/src/network_session/session_handler.h
@@ -52,7 +52,7 @@ public:
     static Kitsunemimi::Project::Common::InternalSessionInterface* m_sessionInterface;
 
     SessionHandler(void* sessionTarget,
-                   void (*processSession)(void*, Session*, const uint64_t),
+                   void (*processSession)(void*, bool, Session*, const uint64_t),
                    void* dataTarget,
                    void (*processData)(void*, Session*, const bool, const void*, const uint64_t),
                    void* errorTarget,

--- a/tests/session_test.h
+++ b/tests/session_test.h
@@ -57,6 +57,9 @@ public:
     std::string m_staticMessage = "";
     std::string m_dynamicMessage = "";
     std::string m_multiBlockMessage = "";
+
+    uint32_t m_numberOfInitSessions = 0;
+    uint32_t m_numberOfEndSessions = 0;
 };
 
 } // namespace Common


### PR DESCRIPTION
The session-callback now has an additional bool-flag to identifiy if the
session starts or ends.